### PR TITLE
fix where newly created tif is accidentally deleted when importing a shapefile

### DIFF
--- a/R/import-to-pg-gr-skey.R
+++ b/R/import-to-pg-gr-skey.R
@@ -273,6 +273,8 @@ import_to_pg_gr_skey <- function(rslt_ind,
 
       if (src_type %in% c("shapefile", "shp")) {
         files <- list.files(path = dirname(src_path), pattern = paste0("^", tools::file_path_sans_ext(basename(src_path)), "\\..*"), ignore.case = TRUE)
+        ## be sure to not delete the newly created .tif
+        files <- files[!grepl("\\.tif$", files, ignore.case = TRUE)]
         for (file in files) {
           file.remove(file.path(out_tif_path, file))
         }

--- a/R/import-to-pg-gr-skey.R
+++ b/R/import-to-pg-gr-skey.R
@@ -272,10 +272,11 @@ import_to_pg_gr_skey <- function(rslt_ind,
       print(glue("Removing {basename(src_path)} from {out_tif_path}"))
 
       if (src_type %in% c("shapefile", "shp")) {
-        files <- list.files(path = dirname(src_path), pattern = paste0("^", tools::file_path_sans_ext(basename(src_path)), "\\..*"), ignore.case = TRUE)
-        ## be sure to not delete the newly created .tif
-        files <- files[!grepl("\\.tif$", files, ignore.case = TRUE)]
-        for (file in files) {
+        dir_name <- dirname(src_path)
+        base_name <- tools::file_path_sans_ext(basename(src_path))
+        pattern <- paste0("^", base_name, "\\.(shp|shx|dbf|prj|sbn|sbx|xml|cpg|shp\\.xml)$")
+        shapefiles <- list.files(path = dir_name, pattern = pattern, ignore.case = TRUE)
+        for (file in shapefiles) {
           file.remove(file.path(out_tif_path, file))
         }
       } else if (src_type == 'gdb') {


### PR DESCRIPTION
Found a bug that when importing a shapefile, after a tif is created, the script then "cleans up" and deletes the source shapefile - but it erroneously  deletes the newly created tif file. This is a fix for that. 